### PR TITLE
Fix Display in-game list crash and log error

### DIFF
--- a/BDTHPlugin/PluginMemory.cs
+++ b/BDTHPlugin/PluginMemory.cs
@@ -239,7 +239,7 @@ namespace BDTHPlugin
 				this.SoftSelectHook.Dispose();
 
 				// Enable the housing goods menu again.
-				this.HousingGoods->IsVisible = true;
+				if (this.HousingGoods != null) this.HousingGoods->IsVisible = true;
 
 				// Kind of pointless if I'm just gonna abort the thread but whatever.
 				this.threadRunning = false;

--- a/BDTHPlugin/PluginUI.cs
+++ b/BDTHPlugin/PluginUI.cs
@@ -213,7 +213,7 @@ namespace BDTHPlugin
 				this.dummyInventory = this.memory.InventoryVisible;
  
 				if (ImGui.Checkbox("Display in-game list", ref this.dummyHousingGoods))
-					this.memory.HousingGoods->IsVisible = this.dummyHousingGoods;
+					if (this.memory.HousingGoods != null) this.memory.HousingGoods->IsVisible = this.dummyHousingGoods;
 				ImGui.SameLine();
 				if (ImGui.Checkbox("Display inventory", ref this.dummyInventory))
 					this.memory.InventoryVisible = this.dummyInventory;

--- a/BDTHPlugin/PluginUI.cs
+++ b/BDTHPlugin/PluginUI.cs
@@ -230,7 +230,7 @@ namespace BDTHPlugin
 
 				ImGui.SameLine();
 				if (ImGui.Button("Place Item"))
-					this.memory.PlaceHousingItem((IntPtr)this.memory.HousingStructure->ActiveItem, this.memory.position);
+					if (this.memory.CanEditItem() && this.memory.HousingStructure->ActiveItem != null) this.memory.PlaceHousingItem((IntPtr)this.memory.HousingStructure->ActiveItem, this.memory.position);
 			}
 			ImGui.End();
 


### PR DESCRIPTION
Fix a crash that happens when "Display in-game list" is pressed out of housing mode and a log error on dispose()